### PR TITLE
Enable setting secure and http only cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Install as an application component, in your config:
 ),
 ```
 
+Install and set http only and secure cookies:
+
+```php
+'components' => array(
+   'detectMobileBrowser' => array(
+       'class' => 'ext.yii-detectmobilebrowser.XDetectMobileBrowser',
+       'secure' => true,
+       'httpOnly' => true,
+    ),
+),
+```
+
 ## Usage
 
 You can get the current user preference like this:

--- a/XDetectMobileBrowser.php
+++ b/XDetectMobileBrowser.php
@@ -21,7 +21,17 @@ class XDetectMobileBrowser extends CApplicationComponent
      * Cookie name for storing detected result
      */
     const COOKIE_NAME_IS = 'isMobile';
- 
+
+    /**
+     * @var bool
+     */
+    public $secure = false;
+
+    /**
+     * @var bool
+     */
+    public $httpOnly = false;
+
     /**
      * @var boolean show mobile version to the client?
      */
@@ -105,9 +115,11 @@ class XDetectMobileBrowser extends CApplicationComponent
         $cookie = new CHttpCookie($cookieName, (int)$value); // bool to int
         $cookie->expire = time()+(3600*24*365); //1 year
         $cookie->path = Yii::app()->baseUrl . '/';
+        $cookie->secure = $this->secure;
+        $cookie->httpOnly = $this->httpOnly;
         Yii::app()->request->cookies[$cookieName] = $cookie;
     }
- 
+
     /**
 	 * Performs a regexp check on the User Agent string to determine if this is a mobile browser.
 	 * I kindly asked them to put their code on GitHub, but no response.

--- a/XDetectMobileBrowser.php
+++ b/XDetectMobileBrowser.php
@@ -23,12 +23,12 @@ class XDetectMobileBrowser extends CApplicationComponent
     const COOKIE_NAME_IS = 'isMobile';
 
     /**
-     * @var bool
+     * @var bool set secure cookies
      */
     public $secure = false;
 
     /**
-     * @var bool
+     * @var bool set http only cookies
      */
     public $httpOnly = false;
 


### PR DESCRIPTION
I have added two public parameters to enable configuring for `secure` and `http only` cookies.

## Usage
Set secure and http only cookies:
```php
'detectMobileBrowser' => array(
            'class' => 'vendor.marcovtwout.yii-detectmobilebrowser.XDetectMobileBrowser',
            'secure' => true,
            'httpOnly' => true,
        ),
```